### PR TITLE
Do not exit boost on CTRL-C so the signal is only sent to the process being run

### DIFF
--- a/boostbuild/main.py
+++ b/boostbuild/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import argparse
 import os
 import re
+import signal
 from typing import List
 
 from colorama import init, Fore
@@ -107,9 +108,17 @@ def get_storage(boost_data: dict, variables: List[str]) -> dict:
     return storage
 
 
+def handler(_signum, _frame):
+    """
+    Handle CTRL-C so the exit signal is sent to the process being executed by boost rather that to boost itself
+    TODO: can we maybe handle multiple signals to send to boost itself.
+    """
+
+
 def main() -> int:
     """Main function"""
     init(autoreset=True)
+    signal.signal(signal.SIGINT, handler)
 
     parser = init_parser()
     args = parser.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boostbuild"
-version = "0.1.12"
+version = "0.1.13"
 description = "Boost is a simple build system that aims to create an interface for shell command substitution across different operative systems."
 authors = ["David Lopez <davidlopez.hellin@outlook.com>"]
 readme = "README.md"


### PR DESCRIPTION
Currently, all CTRL-C was causing boost to exit. In coms cases (like docker-compose) this was causing boost to exit while docker-compose was still trying to shut down containers making the whole process feel irresponsible.
This PR handles the CTRL-C signal by doing nothing but it is still being passed to the process being run by boost, allowing users to exit each process being run by boost but not boost itself.
It may be a good idea to stop boost in case a user presses multiple times CTRL-C.
